### PR TITLE
update call for latest FSLeyes embed

### DIFF
--- a/python/oxford_asl/gui/preview_fsleyes.py
+++ b/python/oxford_asl/gui/preview_fsleyes.py
@@ -81,7 +81,7 @@ def fsleyes_embed(parent=None, make_fsleyesframe=True, **kwargs):
         called[0] = True
         ret[0]    = (overlayList, displayCtx, frame)
 
-    fslgl.getGLContext(parent=parent, ready=ready)
+    fslgl.getGLContext(ready=ready, raiseErrors=True)
     idle.block(10, until=until)
 
     if ret[0] is None:


### PR DESCRIPTION
The asl_gui is broken in FSL 6.0.4

https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?A2=ind2008&L=FSL&O=D&X=D994664A3EAB4D7A7C&Y=taylor.hanayik%40ndcn.ox.ac.uk&P=129575

modifying the one line in this PR fixes things since the FSLeyes embed calls have been modified since this was initially put in asl_gui. 

Will work with Matthew and Paul to see how best to patch the 6.0.4 tar 